### PR TITLE
cli: Refactor parser

### DIFF
--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -1,0 +1,59 @@
+{ const { _ }  = options }
+CommitMessage
+  = title:Title '\n' message:Message {
+   return {
+      prefix: title.prefix,
+      subject: title.subject,
+      fullTitle: title.fullTitle,
+      body: message.body,
+      footers: message.footers,
+      message: message.message
+    };
+  }
+
+Title
+  = prefix:Prefix Colon _ subject:Subject {
+    return {
+      prefix: prefix,
+        subject: subject,
+        fullTitle: prefix + ': ' + subject
+    };
+  }
+
+Message "Message"
+  = b:Body {
+    const lines = b.split('\n')
+    const footerStart = lines.lastIndexOf('')
+    if (footerStart == -1) {
+      throw new Error('Could not parse commit: footers are mandatory and should be separated from the body with a newline')
+    }
+    const body = lines.slice(0, footerStart).join('\n')
+    const footers = lines.slice(footerStart + 1)
+    return {
+     body: body,
+     footers: footers,
+     message: body + '\n\n' + footers.join('\n')
+    }
+  }
+
+Prefix "Prefix"
+  = prefix:[^: \n\t\r]+ {
+    return prefix.join('')
+  }
+
+Colon ":"
+  = ':'
+
+Subject "Subject"
+  = subj:([^\n]+) {
+    return subj.join('')
+  }
+
+
+Body "Body"
+  = body:.+ {
+    return _.trimEnd(body.join(''))
+  }
+
+_ "Space"
+  = ' '

--- a/index.js
+++ b/index.js
@@ -82,5 +82,7 @@ generateErrorReport = (errors) => {
 capitano.run(process.argv, (error) => {
   if (error) {
     generateErrorReport(error)
+  } else {
+    console.log('Valid')
   }
 })

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
     "parse-commit-message": "^1.1.2",
+    "pegjs": "^0.10.0",
     "yaml-js": "^0.2.3"
   },
   "devDependencies": {

--- a/test/parser/commits/space-after-prefix.yml
+++ b/test/parser/commits/space-after-prefix.yml
@@ -1,1 +1,1 @@
-error: "Invalid commit title. Expected <prefix>: <subject>"
+error: "Expected : but \" \" found."


### PR DESCRIPTION
Replace parser with pegjs implementation to improve error reporting

Change-type: minor
Signed-off-by: nazrhom <giovanni@resin.io>