### PR TITLE
feat: Add change-type-fixed-spelling rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ The first letter of any paragraph should be capitalised
 ### change-type
 Each commit must contain the following footer: Change-type: patch|minor|major
 
-### signed-off
+### change-type-fixed-spelling
+Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major
+
+### signed-commits
 Each commit must contain the following footer: Signed-off-by: Full Name &lt;email&gt;
 
 ### signature-last

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "body-lines-max-length": true,
   "capitalise-subject": true,
   "change-type": false,
+  "change-type-fixed-spelling": true,
   "imperative-mood": true,
   "no-period": true,
   "no-tag-in-body": true,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -48,6 +48,14 @@ module.exports.PRETTY_TAGS = (tag) => {
 module.exports.CHANGE_TYPE = Error('Each commit must contain the following footer: Change-type: patch|minor|major')
 
 /**
+* @name change-type-fixed-spelling
+* @description Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major
+* @const
+* @public
+*/
+module.exports.CHANGE_TYPE_FIXED_SPELLING = Error('Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major')
+
+/**
 * @name signed-commits
 * @description Each commit must contain the following footer: Signed-off-by: Full Name <email>
 * @const

--- a/rules/body.js
+++ b/rules/body.js
@@ -6,7 +6,8 @@ const {
   PRETTY_TAGS,
   CHANGE_TYPE,
   SIGNED_COMMITS,
-  SIGNATURE_LAST
+  SIGNATURE_LAST,
+  CHANGE_TYPE_FIXED_SPELLING
 } = require('../lib/errors')
 
 const FOOTER_REGEX = /^([A-Z](\w|-)*): (.+)$/
@@ -66,5 +67,17 @@ module.exports.signatureLast = (commit) => {
   })
   if (signatureIndex === -1 || signatureIndex !== (commit.footers.length - 1)) {
     throw SIGNATURE_LAST
+  }
+}
+
+module.exports.changeTypeFixedSpelling = (commit) => {
+  const changeTypeFooter = _.find(commit.footers, (footer) => {
+    return /^Change-type:.+$/i.test(footer)
+  })
+
+  if (changeTypeFooter) {
+    if (!(/^Change-type: (patch|minor|major)$/.test(changeTypeFooter))) {
+      throw CHANGE_TYPE_FIXED_SPELLING
+    }
   }
 }

--- a/test/body/change-type-fixed-spelling.spec.js
+++ b/test/body/change-type-fixed-spelling.spec.js
@@ -1,0 +1,34 @@
+const ava = require('ava')
+const rules = require('../../rules')
+
+const validFooter = {
+  footers: [ 'Change-type: minor' ]
+}
+const camelCaseFooter = {
+  footers: [ 'Change-Type: minor' ]
+}
+const invalidValueFooter = {
+  footers: [ 'Change-type: foo' ]
+}
+const noChangeTypeFooter = {
+  footers: [ 'Another-footer: foo' ]
+}
+const runTest = (test) => rules.changeTypeFixedSpelling(test)
+
+ava.test('change-type-fixed-spelling: should accept valid footers', (test) => {
+  test.notThrows(() => runTest(validFooter))
+})
+
+ava.test('change-type-fixed-spelling: should reject invalid footers.', (test) => {
+  const error = test.throws(() => runTest(camelCaseFooter))
+  test.is(error.message, 'Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major')
+})
+
+ava.test('change-type-fixed-spelling: should reject invalid footers.', (test) => {
+  const error = test.throws(() => runTest(invalidValueFooter))
+  test.is(error.message, 'Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major')
+})
+
+ava.test('change-type-fixed-spelling: should accept footers with no change-type', (test) => {
+  test.notThrows(() => runTest(noChangeTypeFooter))
+})


### PR DESCRIPTION
This rule enforces the change-type tag to be written
as Change-type: patch|minor|major

This is case-sensitive

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@resin.io>