### PR TITLE
feat: Prefix is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # resin-commit-lint
 
 A script to lint commit messages, a valid commit starts with the title, which is
-made of a prefix, separated from the subject by a colon, the next lines may
+made of an optional prefix, separated from the subject by a colon, the next lines may
 contain the body of the commit followed by the footers.
 
 Scroll to the Rules sections to learn about the specific rules, the default
@@ -17,6 +17,16 @@ A body which may contain several paragraphs.
 It must contain footers separated by a newline
 
 Change-type: major
+Signed-off-by: Foo Bar <foobar@resin.io>
+```
+
+Since the prefix is optional the following is also a valid commit
+
+```
+subject without prefix
+A body
+
+Change-type: minor
 Signed-off-by: Foo Bar <foobar@resin.io>
 ```
 
@@ -51,41 +61,77 @@ Signed-off-by: Fake Name <fakename@resin.io>
 # Rules
 
 ### body-lines-max-length
+*Default: true*
+
 No line in the body should exceed 72 character
 
 ### no-tag-in-body
+*Default: true*
+
 Commit body should not contain footer tags
 
+### no-whitespace-in-prefix
+*Default: true*
+
+Prefix should not contain any whitespace
+
 ### proper-paragraphs
+*Default: true*
+
 The first letter of any paragraph should be capitalised
 
 ### change-type
+*Default: false*
+
 Each commit must contain the following footer: Change-type: patch|minor|major
 
 ### change-type-fixed-spelling
+*Default: true*
+
 Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major
 
 ### signed-commits
+*Default: true*
+
 Each commit must contain the following footer: Signed-off-by: Full Name &lt;email&gt;
 
 ### signature-last
+*Default: true*
+
 Signed-off-by must be the last tag appearing in the footers
 
 ### title-max-length
+*Default: true*
+
 The commit title should not exceed 72 characters
 
 ### capitalise-subject
+*Default: with-prefix*
+
 The commit subject must start with a capital letter
 
+Accepts the following values:
+- *never*: Rule is never applied
+- *always*: Rule is always applied
+- *with-prefix*: Rule is only applied if a valid prefix is supplied
+
 ### no-period
+*Default: true*
+
 The commit title should not end with a period
 
 ### single-space-colon
+*Default: true*
+
 The commit title must include exactly one space after the colon
 
 ### imperative-mood
+*Default: true*
+
 The commit subject must use the imperative mood
 
 ### pretty-tags
+*Default: true*
+
 Tag names must start with a capital letter, only letters and &#x27;-&#x27; are allowed
 

--- a/config.json
+++ b/config.json
@@ -1,11 +1,12 @@
 {
   "body-lines-max-length": true,
-  "capitalise-subject": true,
+  "capitalise-subject": "with-prefix",
   "change-type": false,
   "change-type-fixed-spelling": true,
   "imperative-mood": true,
   "no-period": true,
   "no-tag-in-body": true,
+  "no-whitespace-in-prefix": true,
   "pretty-tags": true,
   "proper-paragraphs": true,
   "signature-last": true,

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -52,6 +52,8 @@ Signed-off-by: Fake Name <fakename@resin.io>
 
 {{#identifiers}}
 ### {{name}}
+*Default: {{default}}*
+
 {{description}}
 
 {{/identifiers}}

--- a/doc/make-docs.js
+++ b/doc/make-docs.js
@@ -1,0 +1,26 @@
+const jsdoc2md = require('jsdoc-to-markdown')
+const fs = require('fs')
+const _ = require('lodash')
+
+const template = fs.readFileSync(__dirname + '/../doc/README.hbs', 'utf8')
+const defaultConfig = require(__dirname + '/../config.json')
+
+const findRuleDefault = (rule) => {
+  if (_.isUndefined(defaultConfig[rule])) {
+    throw new Error('Could not match rule identifier and config')
+  }
+  return defaultConfig[rule]
+}
+const templateData = jsdoc2md.getTemplateDataSync({
+  files: __dirname + '/../lib/errors.js'
+}).map((tpData) => {
+  tpData.default = findRuleDefault(tpData.id)
+  return tpData
+})
+
+const readme = jsdoc2md.renderSync({
+  data: templateData,
+  template: template
+})
+
+fs.writeFileSync(__dirname + '/../README.md', readme)

--- a/index.js
+++ b/index.js
@@ -17,12 +17,15 @@ const parseRule = (command) => {
   }).join('')
 }
 
-const runRules = (commit, activeRules, done) => {
-  _.forEach(activeRules, (rule) => {
+const runRules = (commit, rulesConfig, done) => {
+  _.forEach(rulesConfig, (configuration, rule) => {
+    // Return early if rule is not active
+    if (!configuration) return
+
     const parsedRule = parseRule(rule)
     if (_.isFunction(availableRules[parsedRule])) {
       try {
-        availableRules[parsedRule](commit)
+        availableRules[parsedRule](commit, configuration)
       } catch (err) {
         storedErrors.push(err)
       }
@@ -58,8 +61,8 @@ const parseAndRun = (params, options, done) => {
   }
 
   const configPath = path.join(__dirname, 'config.json')
-  const activeRules = readConfig(options.config || configPath)
-  return runRules(commit, activeRules, done)
+  const rulesConfig = readConfig(options.config || configPath)
+  return runRules(commit, rulesConfig, done)
 }
 
 capitano.command({

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -17,6 +17,14 @@ module.exports.BODY_LINES_MAX_LENGTH = Error('No line in the body should exceed 
 module.exports.NO_TAG_IN_BODY = Error('Commit body should not contain footer tags')
 
 /**
+* @name no-whitespace-in-prefix
+* @description Prefix should not contain any whitespace
+* @const
+* @public
+*/
+module.exports.NO_WHITESPACE_IN_PREFIX = Error('Prefix should not contain any whitespace')
+
+/**
 * @name proper-paragraphs
 * @description The first letter of any paragraph should be capitalised
 * @const
@@ -81,7 +89,13 @@ module.exports.TITLE_MAX_LENGTH = Error('The commit title should not exceed 72 c
 
 /**
 * @name capitalise-subject
-* @description The commit subject must start with a capital letter
+* @description
+* The commit subject must start with a capital letter
+*
+* Accepts the following values:
+* - *never*: Rule is never applied
+* - *always*: Rule is always applied
+* - *with-prefix*: Rule is only applied if a prefix is found
 * @const
 * @public
 */

--- a/lib/grammar/grammar.pegjs
+++ b/lib/grammar/grammar.pegjs
@@ -12,11 +12,16 @@ CommitMessage
   }
 
 Title
-  = prefix:Prefix Colon _ subject:Subject {
+  = prefix:Prefix? subject:Subject {
+    let delimiter = ': '
+    if (!prefix) {
+      prefix    = ''
+      delimiter = ''
+    }
     return {
       prefix: prefix,
-        subject: subject,
-        fullTitle: prefix + ': ' + subject
+      subject: subject,
+      fullTitle: prefix + delimiter + subject
     };
   }
 
@@ -46,7 +51,10 @@ Message "body and footers"
   }
 
 Prefix "prefix"
-  = prefix:[^: \n\t\r]+ {
+  = prefix:[^: \n\t\r]+ extraSpaces:_* Colon _ {
+    if (extraSpaces) {
+      prefix = prefix.concat(extraSpaces)
+    }
     return prefix.join('')
   }
 
@@ -54,8 +62,8 @@ Colon ": between prefix and subject in commit title"
   = ':'
 
 Subject "subject"
-  = subj:([^\n]+) {
-    return subj.join('')
+  = subj:([^:][^\n]+) {
+    return subj[0] + subj[1].join('')
   }
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "npm run lint && nyc --reporter=lcov ava",
-    "readme": "jsdoc2md --template doc/README.hbs lib/errors.js > README.md",
+    "readme": "node doc/make-docs.js",
     "lint": "eslint lib test rules index.js"
   },
   "author": "Resin Inc. <hello@resin.io>",

--- a/rules/title.js
+++ b/rules/title.js
@@ -4,6 +4,7 @@ const {
   TITLE_MAX_LENGTH,
   CAPITALISE_SUBJECT,
   NO_PERIOD,
+  NO_WHITESPACE_IN_PREFIX,
   SINGLE_SPACE_COLON,
   IMPERATIVE_MOOD
 } = require('../lib/errors')
@@ -14,9 +15,24 @@ module.exports.titleMaxLength = (commit) => {
   }
 }
 
-module.exports.capitaliseSubject = (commit) => {
-  if (commit.subject[0] !== commit.subject[0].toUpperCase()) {
-    throw CAPITALISE_SUBJECT
+module.exports.capitaliseSubject = (commit, config) => {
+  const validate = (subject) => {
+    if (subject[0] !== subject[0].toUpperCase()) {
+      throw CAPITALISE_SUBJECT
+    }
+  }
+  switch (config) {
+  case 'with-prefix':
+    if (commit.prefix === '') break
+    validate(commit.subject)
+    break
+  case 'always':
+    validate(commit.subject)
+    break
+  case 'never':
+    break
+  default:
+    throw new Error('Invalid configuration supplied to capitalise-subject')
   }
 }
 
@@ -37,5 +53,11 @@ module.exports.imperativeMood = (commit) => {
   const firstWord = commit.subject.split(' ')[0]
   if (_.find(VERB_BLACKLIST, (word) => word === firstWord.toLowerCase())) {
     throw IMPERATIVE_MOOD
+  }
+}
+
+module.exports.noWhiteSpaceInPrefix = (commit) => {
+  if (/\s/.test(commit.prefix)) {
+    throw NO_WHITESPACE_IN_PREFIX
   }
 }

--- a/test/parser/commits/empty-prefix
+++ b/test/parser/commits/empty-prefix
@@ -1,0 +1,4 @@
+: Subject
+Body
+
+Footer: foo

--- a/test/parser/commits/empty-prefix.yml
+++ b/test/parser/commits/empty-prefix.yml
@@ -1,0 +1,1 @@
+error: 'Expected prefix or subject but ":" found.'

--- a/test/parser/commits/no-colon.yml
+++ b/test/parser/commits/no-colon.yml
@@ -1,1 +1,1 @@
-error: 'Expected : between prefix and subject in commit title but " " found.'
+error: 'Expected newline between title and body but end of input found.'

--- a/test/parser/commits/no-prefix
+++ b/test/parser/commits/no-prefix
@@ -1,0 +1,4 @@
+simple title
+body
+
+Footer: foo

--- a/test/parser/commits/no-prefix-no-body
+++ b/test/parser/commits/no-prefix-no-body
@@ -1,0 +1,3 @@
+simple title
+
+Footer: foo

--- a/test/parser/commits/no-prefix-no-body.yml
+++ b/test/parser/commits/no-prefix-no-body.yml
@@ -1,0 +1,9 @@
+prefix: ''
+subject: 'simple title'
+fullTitle: 'simple title'
+body: ''
+footers:
+- 'Footer: foo'
+message: |-
+
+  Footer: foo

--- a/test/parser/commits/no-prefix.yml
+++ b/test/parser/commits/no-prefix.yml
@@ -1,6 +1,6 @@
-prefix: 'prefix '
-subject: subject
-fullTitle: 'prefix : subject'
+prefix: ''
+subject: 'simple title'
+fullTitle: 'simple title'
 body: body
 footers:
 - 'Footer: foo'

--- a/test/parser/parser.spec.js
+++ b/test/parser/parser.spec.js
@@ -3,20 +3,15 @@ const {
   parse
 } = require('../../lib/parser')
 const fs = require('fs')
+const path = require('path')
 const yaml = require('js-yaml')
 const _ = require('lodash')
 
-_.each([
-  'well-formed-commit',
-  'missing-footer',
-  'space-after-prefix',
-  'space-after-column',
-  'escaped-commit',
-  'only-title',
-  'title-with-newline',
-  'no-body',
-  'no-colon'
-], (testName) => {
+const tests = _.filter(fs.readdirSync(`${__dirname}/commits`), (filename) => {
+  return path.extname(filename) !== '.yml'
+})
+
+_.each(tests, (testName) => {
   const testCase = fs.readFileSync(`${__dirname}/commits/${testName}`, 'utf8')
   const expectedFile = fs.readFileSync(`${__dirname}/commits/${testName}.yml`,
     'utf8')
@@ -25,7 +20,7 @@ _.each([
   ava.test(testCase, (test) => {
     if (expected.error) {
       const error = test.throws(() => {
-        parse(testCase)
+        console.log(parse(testCase))
       })
       test.is(error.message, expected.error)
     } else {

--- a/test/title/capitalise-subject.spec.js
+++ b/test/title/capitalise-subject.spec.js
@@ -7,13 +7,25 @@ const validSubject = {
 const invalidSubject = {
   subject: 'subject'
 }
-const runTest = (test) => rules.capitaliseSubject(test)
+const missingPrefix = {
+  prefix: '',
+  subject: 'subject'
+}
+const runTest = (test, config) => rules.capitaliseSubject(test, config)
 
-ava.test('capitalise-subject: should accept valid subject', (test) => {
-  test.notThrows(() => runTest(validSubject))
+ava.test('capitalise-subject[always]: should accept valid subject', (test) => {
+  test.notThrows(() => runTest(validSubject, 'always'))
 })
 
-ava.test('capitalise-subject: should reject invalid subject.', (test) => {
-  const error = test.throws(() => runTest(invalidSubject))
+ava.test('capitalise-subject[always]: should reject invalid subject.', (test) => {
+  const error = test.throws(() => runTest(invalidSubject, 'always'))
   test.is(error.message, 'The commit subject must start with a capital letter')
+})
+
+ava.test('capitalise-subject[with-prefix]: should accept lowercase subject when prefix is missing', (test) => {
+  test.notThrows(() => runTest(missingPrefix, 'with-prefix'))
+})
+
+ava.test('capitalise-subject[never]: should accept invalid subject', (test) => {
+  test.notThrows(() => runTest(invalidSubject, 'never'))
 })

--- a/test/title/no-whitespace-in-prefix.spec.js
+++ b/test/title/no-whitespace-in-prefix.spec.js
@@ -1,0 +1,36 @@
+const ava = require('ava')
+const rules = require('../../rules')
+
+const validPrefix = {
+  prefix: 'prefix'
+}
+const spacePrefix = {
+  prefix: 'prefix '
+}
+const tabPrefix = {
+  prefix: 'prefix\t'
+}
+const newlinePrefix = {
+  prefix: 'prefix\n'
+}
+
+const runTest = (test) => rules.noWhiteSpaceInPrefix(test)
+
+ava.test('no-whitespace-in-prefix: should accept valid prefix', (test) => {
+  test.notThrows(() => runTest(validPrefix))
+})
+
+ava.test('no-whitespace-in-prefix: should reject invalid prefix.', (test) => {
+  const error = test.throws(() => runTest(spacePrefix))
+  test.is(error.message, 'Prefix should not contain any whitespace')
+})
+
+ava.test('no-whitespace-in-prefix: should reject invalid prefix.', (test) => {
+  const error = test.throws(() => runTest(tabPrefix))
+  test.is(error.message, 'Prefix should not contain any whitespace')
+})
+
+ava.test('no-whitespace-in-prefix: should reject invalid prefix.', (test) => {
+  const error = test.throws(() => runTest(newlinePrefix))
+  test.is(error.message, 'Prefix should not contain any whitespace')
+})


### PR DESCRIPTION
Added support for parametrised rules.

The new defaults will mirror the old behaviour in rejecting commits witha prefix but lowercase subject.

When the prefix is omitted, the subject may be lowercase.

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@resin.io>