### PR TITLE
config: Change default config and rename rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,15 @@ Signed-off-by: Your Name <yourname@resin.io>
 
 No line in the body should exceed 72 character
 
-## no-tag-in-body
-*Default: true*
+## capitalise-subject
+*Default: with-prefix*
 
-Commit body should not contain footer tags
+The commit subject must start with a capital letter
 
-## no-whitespace-in-prefix
-*Default: true*
-
-Prefix should not contain any whitespace
-
-## proper-paragraphs
-*Default: true*
-
-The first letter of any paragraph should be capitalised
+Accepts the following values:
+- *never*: Rule is never applied
+- *always*: Rule is always applied
+- *with-prefix*: Rule is only applied if a prefix is found
 
 ## change-type
 *Default: false*
@@ -94,35 +89,15 @@ Each commit must contain the following footer: Change-type: patch|minor|major
 
 Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major
 
-## signed-commits
+## imperative-mood
 *Default: true*
 
-Each commit must contain the following footer: Signed-off-by: Full Name <email\>
+The commit subject must use the imperative mood
 
-## signature-last
+## newline-before-body
 *Default: true*
 
-Signed-off-by must be the last tag appearing in the footers
-
-## title-max-length
-*Default: true*
-
-The commit title should not exceed 72 characters
-
-## capitalise-subject
-*Default: with-prefix*
-
-The commit subject must start with a capital letter
-
-Accepts the following values:
-- *never*: Rule is never applied
-- *always*: Rule is always applied
-- *with-prefix*: Rule is only applied if a prefix is found
-
-## no-period
-*Default: true*
-
-The commit title should not end with a period
+The body must be separeted from title by a newline
 
 ## no-leading-space-in-subject
 *Default: true*
@@ -148,13 +123,43 @@ prefix:  subject
  subject
 ```
 
-## imperative-mood
+## no-period
 *Default: true*
 
-The commit subject must use the imperative mood
+The commit title should not end with a period
+
+## no-tag-in-body
+*Default: true*
+
+Commit body should not contain footer tags
+
+## no-whitespace-in-prefix
+*Default: true*
+
+Prefix should not contain any whitespace
 
 ## pretty-tags
 *Default: true*
 
 Tag names must start with a capital letter, only letters and '-' are allowed
+
+## proper-paragraphs
+*Default: true*
+
+The first letter of any paragraph should be capitalised
+
+## signature-last
+*Default: false*
+
+Signed-off-by must be the last tag appearing in the footers
+
+## signed-off-commits
+*Default: true*
+
+Each commit must contain the following footer: Signed-off-by: Full Name <email\>
+
+## title-max-length
+*Default: true*
+
+The commit title should not exceed 72 characters
 

--- a/config.json
+++ b/config.json
@@ -4,13 +4,14 @@
   "change-type": false,
   "change-type-fixed-spelling": true,
   "imperative-mood": true,
+  "newline-before-body": true,
   "no-leading-space-in-subject": true,
   "no-period": true,
   "no-tag-in-body": true,
   "no-whitespace-in-prefix": true,
   "pretty-tags": true,
   "proper-paragraphs": true,
-  "signature-last": true,
-  "signed-commits": true,
+  "signature-last": false,
+  "signed-off-commits": true,
   "title-max-length": true
 }

--- a/doc/make-docs.js
+++ b/doc/make-docs.js
@@ -19,7 +19,7 @@ const templateData = jsdoc2md.getTemplateDataSync({
 })
 
 const readme = jsdoc2md.renderSync({
-  data: templateData,
+  data: _.sortBy(templateData, 'id'),
   template: template
 })
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -64,12 +64,12 @@ module.exports.CHANGE_TYPE = Error('Each commit must contain the following foote
 module.exports.CHANGE_TYPE_FIXED_SPELLING = Error('Change-type should follow this exact format (case-sensitive): Change-type: patch|minor|major')
 
 /**
-* @name signed-commits
+* @name signed-off-commits
 * @description Each commit must contain the following footer: Signed-off-by: Full Name <email\>
 * @const
 * @public
 */
-module.exports.SIGNED_COMMITS = Error('Each commit must contain the following footer: Signed-off-by: Full Name <email>')
+module.exports.SIGNED_OFF_COMMITS = Error('Each commit must contain the following footer: Signed-off-by: Full Name <email>')
 
 /**
 * @name signature-last
@@ -145,3 +145,11 @@ module.exports.NO_LEADING_SPACE_IN_SUBJECT = Error('The commit subject must not 
 * @public
 */
 module.exports.IMPERATIVE_MOOD = Error('The commit subject must use the imperative mood')
+
+/**
+* @name newline-before-body
+* @description The body must be separeted from title by a newline
+* @const
+* @public
+*/
+module.exports.NEWLINE_BEFORE_BODY = Error('The body must be separeted from title by a newline')

--- a/rules/body.js
+++ b/rules/body.js
@@ -5,9 +5,10 @@ const {
   PROPER_PARAGRAPHS,
   PRETTY_TAGS,
   CHANGE_TYPE,
-  SIGNED_COMMITS,
+  SIGNED_OFF_COMMITS,
   SIGNATURE_LAST,
-  CHANGE_TYPE_FIXED_SPELLING
+  CHANGE_TYPE_FIXED_SPELLING,
+  NEWLINE_BEFORE_BODY
 } = require('../lib/errors')
 
 const FOOTER_REGEX = /^([A-Z](\w|-)*): (.+)$/
@@ -52,12 +53,12 @@ module.exports.changeType = (commit) => {
   }
 }
 
-module.exports.signedCommits = (commit) => {
+module.exports.signedOffCommits = (commit) => {
   const signedOffByFooter = _.find(commit.footers, (footer) => {
     return /^Signed-off-by: (.+) <(.+)>$/.test(footer)
   })
   if (!signedOffByFooter) {
-    throw SIGNED_COMMITS
+    throw SIGNED_OFF_COMMITS
   }
 }
 
@@ -79,5 +80,11 @@ module.exports.changeTypeFixedSpelling = (commit) => {
     if (!(/^Change-type: (patch|minor|major)$/.test(changeTypeFooter))) {
       throw CHANGE_TYPE_FIXED_SPELLING
     }
+  }
+}
+
+module.exports.newlineBeforeBody = (commit) => {
+  if (commit.body !== '' && commit.body[0] !== '\n') {
+    throw NEWLINE_BEFORE_BODY
   }
 }

--- a/test/body/newline-before-body.spec.js
+++ b/test/body/newline-before-body.spec.js
@@ -1,0 +1,27 @@
+const ava = require('ava')
+const rules = require('../../rules')
+
+const validBody = {
+  body: '\nBody'
+}
+const invalidBody = {
+  body: 'body'
+}
+const invalidBodySpacing = {
+  body: '\tbody'
+}
+const runTest = (test) => rules.newlineBeforeBody(test)
+
+ava.test('newline-before-body: should accept valid body', (test) => {
+  test.notThrows(() => runTest(validBody))
+})
+
+ava.test('newline-before-body: should reject invalid body.', (test) => {
+  const error = test.throws(() => runTest(invalidBody))
+  test.is(error.message, 'The body must be separeted from title by a newline')
+})
+
+ava.test('newline-before-body: should reject invalid body.', (test) => {
+  const error = test.throws(() => runTest(invalidBodySpacing))
+  test.is(error.message, 'The body must be separeted from title by a newline')
+})

--- a/test/body/signed-off-commits.spec.js
+++ b/test/body/signed-off-commits.spec.js
@@ -13,7 +13,7 @@ const noNameFooter = {
 const noSignatureFooter = {
   footers: [ 'Another-footer: foo' ]
 }
-const runTest = (test) => rules.signedCommits(test)
+const runTest = (test) => rules.signedOffCommits(test)
 
 ava.test('signed-commits: should accept valid footers', (test) => {
   test.notThrows(() => runTest(validFooter))

--- a/test/e2e/commits/escaped-commit
+++ b/test/e2e/commits/escaped-commit
@@ -1,4 +1,5 @@
 prefix: Subject
+
 A body which may contain several paragraphs.
 
 It must contain footers separated by a newline,

--- a/test/e2e/commits/escaped-commit.yml
+++ b/test/e2e/commits/escaped-commit.yml
@@ -2,6 +2,7 @@ prefix: prefix
 subject: Subject
 fullTitle: 'prefix: Subject'
 body: |-
+  
   A body which may contain several paragraphs.
 
   It must contain footers separated by a newline,
@@ -10,6 +11,7 @@ footers:
 - 'Change-type: minor'
 - 'Signed-off-by: foobar <foobar@resin.io>'
 message: |-
+  
   A body which may contain several paragraphs.
 
   It must contain footers separated by a newline,

--- a/test/e2e/commits/no-prefix-no-body.yml
+++ b/test/e2e/commits/no-prefix-no-body.yml
@@ -9,5 +9,4 @@ message: |-
   Footer: foo
 
 errors:
-- 'Signed-off-by must be the last tag appearing in the footers'
 - 'Each commit must contain the following footer: Signed-off-by: Full Name <email>'

--- a/test/e2e/commits/no-prefix.yml
+++ b/test/e2e/commits/no-prefix.yml
@@ -10,5 +10,5 @@ message: |-
   Footer: foo
 
 errors:
-- 'Signed-off-by must be the last tag appearing in the footers'
+- 'The body must be separeted from title by a newline'
 - 'Each commit must contain the following footer: Signed-off-by: Full Name <email>'

--- a/test/e2e/commits/space-after-column.yml
+++ b/test/e2e/commits/space-after-column.yml
@@ -10,6 +10,6 @@ footers:
 - 'Footer: foo'
 
 errors:
+- 'The body must be separeted from title by a newline'
 - 'The commit subject must not start with a leading space'
-- 'Signed-off-by must be the last tag appearing in the footers'
 - 'Each commit must contain the following footer: Signed-off-by: Full Name <email>'

--- a/test/e2e/commits/space-after-prefix.yml
+++ b/test/e2e/commits/space-after-prefix.yml
@@ -10,7 +10,7 @@ message: |-
   Footer: foo
 
 errors:
-  - 'The commit subject must start with a capital letter'
-  - 'Prefix should not contain any whitespace'
-  - 'Signed-off-by must be the last tag appearing in the footers'
-  - 'Each commit must contain the following footer: Signed-off-by: Full Name <email>'
+- 'The commit subject must start with a capital letter'
+- 'The body must be separeted from title by a newline'
+- 'Prefix should not contain any whitespace'
+- 'Each commit must contain the following footer: Signed-off-by: Full Name <email>'

--- a/test/e2e/commits/well-formed-commit
+++ b/test/e2e/commits/well-formed-commit
@@ -1,4 +1,5 @@
 prefix: Subject
+
 A body which may contain several paragraphs.
 
 It must contain footers separated by a newline

--- a/test/e2e/commits/well-formed-commit.yml
+++ b/test/e2e/commits/well-formed-commit.yml
@@ -2,6 +2,7 @@ prefix: prefix
 subject: Subject
 fullTitle: 'prefix: Subject'
 body: |-
+  
   A body which may contain several paragraphs.
 
   It must contain footers separated by a newline
@@ -9,6 +10,7 @@ footers:
 - 'Change-type: minor'
 - 'Signed-off-by: foobar <foobar@resin.io>'
 message: |-
+  
   A body which may contain several paragraphs.
 
   It must contain footers separated by a newline

--- a/test/e2e/e2e.spec.js
+++ b/test/e2e/e2e.spec.js
@@ -39,10 +39,10 @@ _.each(tests, (testName) => {
 
       const defaultConfig = readConfig(getDefaultConfigPath())
       runRules(parseResult, defaultConfig, (errs) => {
-        const errorMessages = _.map(errs, (err) => {
-          return err.message
-        })
-        if (expected.errors) {
+        if (errs) {
+          const errorMessages = _.map(errs, (err) => {
+            return err.message
+          })
           test.deepEqual(errorMessages, expected.errors)
         }
       })


### PR DESCRIPTION
Change signature-last to default to false.

Rename signed-commits to signed-off-commits

Add newline-before-body
Requires a newline to be present between the commit title and body

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@resin.io>