### PR TITLE
Allow body tags

### DIFF
--- a/lib/grammar/grammar.pegjs
+++ b/lib/grammar/grammar.pegjs
@@ -70,7 +70,7 @@ Body "body"
 	}
 
 Footers "footers" =
-	Newline f:Footer fs:(Newline x:Footer { return x })* Newline? {
+	Newline f:Footer fs:(Newline x:Footer { return x })* Newline? !Text {
 		return _.compact([f].concat(fs))
 	}
 
@@ -81,3 +81,6 @@ notEOL = [^\r\n]
 
 _ "space"
 	= ' '
+
+Text "text"
+	= [^WHAT]

--- a/test/e2e/commits/body-tag
+++ b/test/e2e/commits/body-tag
@@ -1,0 +1,6 @@
+prefix: Subject
+
+Body: Text
+
+Change-type: minor
+Signed-off-by: foobar <foobar@resin.io>

--- a/test/e2e/commits/body-tag.yml
+++ b/test/e2e/commits/body-tag.yml
@@ -1,0 +1,12 @@
+body: 'Body: Text'
+footers:
+  - 'Change-type: minor'
+  - 'Signed-off-by: foobar <foobar@resin.io>'
+fullTitle: 'prefix: Subject'
+message: |-
+  Body: Text
+
+  Change-type: minor
+  Signed-off-by: foobar <foobar@resin.io>
+prefix: 'prefix'
+subject: 'Subject'


### PR DESCRIPTION
Allow tags in body and correctly get the footers when they exist

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>